### PR TITLE
Adding features

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ npx -y @smithery/cli@latest install @SaseQ/discord-mcp --client claude
  - [`remove_reaction`](): Remove a specified reaction (emoji) from a message
 
 #### Channel Management
+ - [`createTextChannel`](): Create text a channel
  - [`delete_channel`](): Delete a channel
  - [`find_channel`](): Find a channel type and ID using name and server ID
  - [`list_channels`](): List of all channels

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ npx -y @smithery/cli@latest install @SaseQ/discord-mcp --client claude
  - [`remove_reaction`](): Remove a specified reaction (emoji) from a message
 
 #### Channel Management
- - [`createTextChannel`](): Create text a channel
+ - [`create_text_channel`](): Create text a channel
  - [`delete_channel`](): Delete a channel
  - [`find_channel`](): Find a channel type and ID using name and server ID
  - [`list_channels`](): List of all channels

--- a/src/main/java/dev/saseq/services/DiscordService.java
+++ b/src/main/java/dev/saseq/services/DiscordService.java
@@ -325,6 +325,36 @@ public class DiscordService {
         return "Deleted " + channel.getType().name() + " channel: " + channel.getName();
     }
 
+    @Tool(name = "create_text_channel", description = "Create a new text channel")
+    public String createTextChannel(@ToolParam(description = "Discord server ID") String guildId,
+                                    @ToolParam(description = "Channel name") String name,
+                                    @ToolParam(description = "Category ID (optional)", required = false) String categoryId) {
+        if (guildId == null || guildId.isEmpty()) {
+            throw new IllegalArgumentException("guildId cannot be null");
+        }
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("name cannot be null");
+        }
+
+        Guild guild = jda.getGuildById(guildId);
+        if (guild == null) {
+            throw new IllegalArgumentException("Discord server not found by guildId");
+        }
+        
+        TextChannel textChannel;
+        if (categoryId != null && !categoryId.isEmpty()) {
+            Category category = guild.getCategoryById(categoryId);
+            if (category == null) {
+                throw new IllegalArgumentException("Category not found by categoryId");
+            }
+            textChannel = category.createTextChannel(name).complete();
+            return "Created new text channel: " + textChannel.getName() + " (ID: " + textChannel.getId() + ") in category: " + category.getName();
+        } else {
+            textChannel = guild.createTextChannel(name).complete();
+            return "Created new text channel: " + textChannel.getName() + " (ID: " + textChannel.getId() + ")";
+        }
+    }
+
     @Tool(name = "find_channel", description = "Find a channel type and ID using name and server ID")
     public String findChannel(@ToolParam(description = "Discord server ID") String guildId,
                               @ToolParam(description = "Discord category name") String channelName) {


### PR DESCRIPTION
Add Tool - ''create_text_channel"

I've added a new function called `create_text_channel` with the `@Tool` annotation and name "create_text_channel". This function:

1. Takes three parameters:
   - `guildId`: The Discord server ID (required)
   - `name`: The name for the new text channel (required)
   - `categoryId`: An optional parameter for the category ID to place the channel in
2. Has proper validation for the input parameters
3. Creates a text channel either:
   - In the specified category if a valid categoryId is provided
   - At the top level of the server if no categoryId is provided or if it's empty
4. Returns a success message with the new channel's name and ID

This new function will allow you to create text channels both at the server's root level and within specific categories. The functionality matches the existing pattern used by other methods in the class and follows the same error handling approach.