### PR TITLE
Retrieve Discord User ID by Username

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ npx -y @smithery/cli@latest install @SaseQ/discord-mcp --client claude
  - [`edit_message`](): Edit a message from a specific channel
  - [`delete_message`](): Delete a message from a specific channel
  - [`read_messages`](): Read recent message history from a specific channel
+ - [`get_user_id_by_name`](): Get a Discord user's ID by username in a guild for ping usage `<@id>`
  - [`send_private_message`](): Send a private message to a specific user
  - [`edit_private_message`](): Edit a private message from a specific user
  - [`delete_private_message`](): Delete a private message from a specific user

--- a/src/main/java/dev/saseq/services/DiscordService.java
+++ b/src/main/java/dev/saseq/services/DiscordService.java
@@ -23,6 +23,60 @@ public class DiscordService {
         this.jda = jda;
     }
 
+    private String resolveGuildId(String guildId) {
+        if ((guildId == null || guildId.isEmpty()) && defaultGuildId != null && !defaultGuildId.isEmpty()) {
+            return defaultGuildId;
+        }
+        return guildId;
+    }
+
+    /**
+     * Public tool to retrieve a Discord user's ID by their username (optionally with discriminator) in a guild.
+     * @param username Username (optionally in the format username#discriminator)
+     * @param guildId Optional guild/server ID; uses default if not provided
+     * @return User ID string if found, or error message
+     */
+    @Tool(name = "get_user_id_by_name", description = "Get a Discord user's ID by username in a guild for ping usage <@id>.")
+    public String getUserIdByName(
+            @ToolParam(description = "Discord username (optionally username#discriminator)") String username,
+            @ToolParam(description = "Discord server ID", required = false) String guildId) {
+        if (username == null || username.isEmpty()) {
+            throw new IllegalArgumentException("username cannot be null");
+        }
+        guildId = resolveGuildId(guildId);
+        if (guildId == null || guildId.isEmpty()) {
+            throw new IllegalArgumentException("guildId cannot be null");
+        }
+        Guild guild = jda.getGuildById(guildId);
+        if (guild == null) {
+            throw new IllegalArgumentException("Discord server not found by guildId");
+        }
+        String name = username;
+        String discriminatorLocal = null;
+        if (username.contains("#")) {
+            int idx = username.lastIndexOf('#');
+            name = username.substring(0, idx);
+            discriminatorLocal = username.substring(idx + 1);
+        }
+        List<Member> members = guild.getMemberCache().getElementsByUsername(name, true);
+        if (discriminatorLocal != null) {
+            final String finalDiscriminator = discriminatorLocal;
+            members = members.stream()
+                    .filter(m -> m.getUser().getDiscriminator().equals(finalDiscriminator))
+                    .toList();
+        }
+        if (members.isEmpty()) {
+            throw new IllegalArgumentException("No user found with username " + username);
+        }
+        if (members.size() > 1) {
+            String userList = members.stream()
+                    .map(m -> m.getUser().getName() + "#" + m.getUser().getDiscriminator() + " (ID: " + m.getUser().getId() + ")")
+                    .collect(Collectors.joining(", "));
+            throw new IllegalArgumentException("Multiple users found with username '" + username + "'. List: " + userList + ". Please specify the full username#discriminator.");
+        }
+        return members.get(0).getUser().getId();
+    }
+
     @Tool(name = "get_server_info", description = "Get detailed discord server information")
     public String getServerInfo(@ToolParam(description = "Discord server ID") String guildId) {
         if (guildId == null || guildId.isEmpty()) {


### PR DESCRIPTION
Add tool to fetch Discord user ID by username

- New public tool: `get_user_id_by_name`
- Lets you find a user's Discord ID by their username
- Handles multiple or missing users with clear errors
- README updated to document the new tool

> ⚠️ Note: This tool only works for users present in the cache, that is, users who have sent messages recently or whose data has already been loaded by the bot. If a user has never interacted in the server while the bot was running, they will not be found.

If you need to ping or automate actions for users but only have their username, you can now instantly get their user ID for `<@id>` mentions or bot logic.

This makes user lookups much easier, no more manual searching or claiming IDs.