### PR TITLE
Add thread support

### DIFF
--- a/src/main/java/dev/saseq/configs/DiscordMcpConfig.java
+++ b/src/main/java/dev/saseq/configs/DiscordMcpConfig.java
@@ -6,6 +6,7 @@ import dev.saseq.services.UserService;
 import dev.saseq.services.ChannelService;
 import dev.saseq.services.CategoryService;
 import dev.saseq.services.WebhookService;
+import dev.saseq.services.ThreadService;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.requests.GatewayIntent;
@@ -23,14 +24,16 @@ public class DiscordMcpConfig {
                                              UserService userService,
                                              ChannelService channelService,
                                              CategoryService categoryService,
-                                             WebhookService webhookService) {
+                                             WebhookService webhookService,
+                                             ThreadService threadService) {
         return MethodToolCallbackProvider.builder().toolObjects(
                 discordService,
                 messageService,
                 userService,
                 channelService,
                 categoryService,
-                webhookService
+                webhookService,
+                threadService
         ).build();
     }
 

--- a/src/main/java/dev/saseq/services/ThreadService.java
+++ b/src/main/java/dev/saseq/services/ThreadService.java
@@ -1,0 +1,67 @@
+package dev.saseq.services;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ThreadService {
+
+    private final JDA jda;
+
+    @Value("${DISCORD_GUILD_ID:}")
+    private String defaultGuildId;
+
+    public ThreadService(JDA jda) {
+        this.jda = jda;
+    }
+
+    private String resolveGuildId(String guildId) {
+        if ((guildId == null || guildId.isEmpty()) && defaultGuildId != null && !defaultGuildId.isEmpty()) {
+            return defaultGuildId;
+        }
+        return guildId;
+    }
+
+    /**
+     * Lists all active threads in a specified Discord server.
+     *
+     * @param guildId Optional ID of the Discord server (guild). If not provided, the default server will be used.
+     * @return A formatted string listing all active threads in the server, including their name, ID, and parent channel.
+     */
+    @Tool(name = "list_active_threads", description = "List all active threads in the server")
+    public String listActiveThreads(@ToolParam(description = "Discord server ID", required = false) String guildId) {
+        guildId = resolveGuildId(guildId);
+        if (guildId == null || guildId.isEmpty()) {
+            throw new IllegalArgumentException("guildId cannot be null");
+        }
+
+        Guild guild = jda.getGuildById(guildId);
+        if (guild == null) {
+            throw new IllegalArgumentException("Discord server not found by guildId");
+        }
+
+        // Retrieve active threads from Discord API
+        List<ThreadChannel> threads = guild.retrieveActiveThreads().complete();
+
+        if (threads.isEmpty()) {
+            return "No active threads found in the server.";
+        }
+
+        return "Retrieved " + threads.size() + " active threads:\n" +
+                threads.stream()
+                        .map(t -> {
+                            String parentName = t.getParentChannel() != null ? t.getParentChannel().getName() : "unknown";
+                            String archived = t.isArchived() ? " (archived)" : "";
+                            return "- " + t.getName() + " (ID: " + t.getId() + ") in #" + parentName + archived;
+                        })
+                        .collect(Collectors.joining("\n"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `list_active_threads` tool to discover active threads in a server
- Fix `read_messages` (and other message tools) to work with thread channel IDs

## Changes
- New `ThreadService.java` with `list_active_threads` tool using `guild.retrieveActiveThreads()`
- Updated `MessageService.java` to check both `TextChannel` and `ThreadChannel` when looking up channels
- Wired `ThreadService` into `DiscordMcpConfig.java`

## Why
Previously, there was no way to discover thread IDs, and `read_messages` failed on thread channels because it only checked `jda.getTextChannelById()`. Threads are a separate channel type in Discord's API.

---

*This PR was written by Claude Code with empirical testing.*