### PR TITLE
fix: await JDA ready before returning from bean initialization

### DIFF
--- a/src/main/java/dev/saseq/configs/DiscordMcpConfig.java
+++ b/src/main/java/dev/saseq/configs/DiscordMcpConfig.java
@@ -35,13 +35,14 @@ public class DiscordMcpConfig {
     }
 
     @Bean
-    public JDA jda(@Value("${DISCORD_TOKEN:}") String token) {
+    public JDA jda(@Value("${DISCORD_TOKEN:}") String token) throws InterruptedException {
         if (token == null || token.isEmpty()) {
             System.err.println("ERROR: The environment variable DISCORD_TOKEN is not set. Please set it to run the application properly.");
             System.exit(1);
         }
         return JDABuilder.createDefault(token)
                 .enableIntents(GatewayIntent.GUILD_MEMBERS)
-                .build();
+                .build()
+                .awaitReady();
     }
 }


### PR DESCRIPTION
## Summary
- Added `awaitReady()` call after `build()` to ensure the gateway connection is established before tools use JDA

## Problem
The JDA instance was being returned immediately after `build()`, but JDA connects to Discord's gateway asynchronously. This caused `getGuildById()` to return null with the error "Discord server not found by guildId" because the guild cache hadn't been populated yet.

## Solution
Adding `awaitReady()` ensures the gateway connection is established and the guild cache is populated before any tools attempt to use it.

## Test plan
- [x] Verified the fix resolves the "Discord server not found" error when using tools immediately after container startup