### PR TITLE
Add attachment metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,13 +175,14 @@ claude mcp add mcp-server -- docker run --rm -i -e DISCORD_TOKEN=<YOUR_DISCORD_B
 - [`send_private_message`](): Send a private message to a specific user
 - [`edit_private_message`](): Edit a private message from a specific user
 - [`delete_private_message`](): Delete a private message from a specific user
-- [`read_private_messages`](): Read recent message history from a specific user
+- [`read_private_messages`](): Read recent message history from a specific user (includes attachment metadata)
 
 #### Message Management
  - [`send_message`](): Send a message to a specific channel
  - [`edit_message`](): Edit a message from a specific channel
  - [`delete_message`](): Delete a message from a specific channel
- - [`read_messages`](): Read recent message history from a specific channel
+ - [`read_messages`](): Read recent message history from a specific channel (includes attachment metadata)
+ - [`get_attachment`](): Get attachment metadata from a specific message
  - [`add_reaction`](): Add a reaction (emoji) to a specific message
  - [`remove_reaction`](): Remove a specified reaction (emoji) from a message
 

--- a/src/main/java/dev/saseq/services/MessageService.java
+++ b/src/main/java/dev/saseq/services/MessageService.java
@@ -276,13 +276,20 @@ public class MessageService {
 
     private String formatAttachmentDetail(Message.Attachment attachment) {
         return String.format(
-                "- (Attachment ID: %s) `%s` (%s, %s)\n  URL: %s\n  Proxy URL: %s",
+                "- %s\n  Proxy URL: %s",
+                formatAttachmentSummary(attachment),
+                attachment.getProxyUrl()
+        );
+    }
+
+    private String formatAttachmentSummary(Message.Attachment attachment) {
+        return String.format(
+                "(Attachment ID: %s) `%s` (%s, %s) URL: %s",
                 attachment.getId(),
                 attachment.getFileName(),
                 formatFileSize(attachment.getSize()),
                 attachment.getContentType() != null ? attachment.getContentType() : "unknown",
-                attachment.getUrl(),
-                attachment.getProxyUrl()
+                attachment.getUrl()
         );
     }
 
@@ -301,12 +308,7 @@ public class MessageService {
                     if (!attachments.isEmpty()) {
                         sb.append("\n  Attachments:");
                         for (Message.Attachment attachment : attachments) {
-                            sb.append(String.format("\n    - (Attachment ID: %s) `%s` (%s, %s) URL: %s",
-                                    attachment.getId(),
-                                    attachment.getFileName(),
-                                    formatFileSize(attachment.getSize()),
-                                    attachment.getContentType() != null ? attachment.getContentType() : "unknown",
-                                    attachment.getUrl()));
+                            sb.append("\n    - ").append(formatAttachmentSummary(attachment));
                         }
                     }
 

--- a/src/main/java/dev/saseq/services/MessageService.java
+++ b/src/main/java/dev/saseq/services/MessageService.java
@@ -222,15 +222,102 @@ public class MessageService {
         return "Removed reaction successfully. Message link: " + message.getJumpUrl();
     }
 
+    /**
+     * Retrieves attachment metadata from a specific message in a Discord channel.
+     *
+     * @param channelId    The ID of the channel containing the message.
+     * @param messageId    The ID of the message to retrieve attachments from.
+     * @param attachmentId Optional ID of a specific attachment (if omitted, returns all).
+     * @return A formatted string containing attachment metadata.
+     */
+    @Tool(name = "get_attachment", description = "Get attachment metadata (filename, size, content type, URLs) from a specific message. Returns info only, does not download files.")
+    public String getAttachment(@ToolParam(description = "Discord channel ID") String channelId,
+                                @ToolParam(description = "Discord message ID") String messageId,
+                                @ToolParam(description = "Specific attachment ID (omit to get all attachments)", required = false) String attachmentId) {
+        if (channelId == null || channelId.isEmpty()) {
+            throw new IllegalArgumentException("channelId cannot be null");
+        }
+        if (messageId == null || messageId.isEmpty()) {
+            throw new IllegalArgumentException("messageId cannot be null");
+        }
+
+        MessageChannel channel = getMessageChannelById(channelId);
+        if (channel == null) {
+            throw new IllegalArgumentException("Channel not found by channelId");
+        }
+        Message message = channel.retrieveMessageById(messageId).complete();
+        if (message == null) {
+            throw new IllegalArgumentException("Message not found by messageId");
+        }
+
+        List<Message.Attachment> attachments = message.getAttachments();
+        if (attachments.isEmpty()) {
+            return "This message has no attachments.";
+        }
+
+        if (attachmentId != null && !attachmentId.isEmpty()) {
+            Message.Attachment attachment = attachments.stream()
+                    .filter(a -> a.getId().equals(attachmentId))
+                    .findFirst()
+                    .orElse(null);
+            if (attachment == null) {
+                throw new IllegalArgumentException("Attachment not found by attachmentId");
+            }
+            return formatAttachmentDetail(attachment);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("**Found ").append(attachments.size()).append(" attachment(s):**\n");
+        for (Message.Attachment attachment : attachments) {
+            sb.append(formatAttachmentDetail(attachment)).append("\n");
+        }
+        return sb.toString().trim();
+    }
+
+    private String formatAttachmentDetail(Message.Attachment attachment) {
+        return String.format(
+                "- (Attachment ID: %s) `%s` (%s, %s)\n  URL: %s\n  Proxy URL: %s",
+                attachment.getId(),
+                attachment.getFileName(),
+                formatFileSize(attachment.getSize()),
+                attachment.getContentType() != null ? attachment.getContentType() : "unknown",
+                attachment.getUrl(),
+                attachment.getProxyUrl()
+        );
+    }
+
     private List<String> formatMessages(List<Message> messages) {
         return messages.stream()
                 .map(m -> {
                     String authorName = m.getAuthor().getName();
                     String timestamp = m.getTimeCreated().toString();
                     String content = m.getContentDisplay();
-                    String messageId = m.getId();
+                    String msgId = m.getId();
 
-                    return String.format("- (ID: %s) **[%s]** `%s`: ```%s```", messageId, authorName, timestamp, content);
+                    StringBuilder sb = new StringBuilder();
+                    sb.append(String.format("- (ID: %s) **[%s]** `%s`: ```%s```", msgId, authorName, timestamp, content));
+
+                    List<Message.Attachment> attachments = m.getAttachments();
+                    if (!attachments.isEmpty()) {
+                        sb.append("\n  Attachments:");
+                        for (Message.Attachment attachment : attachments) {
+                            sb.append(String.format("\n    - (Attachment ID: %s) `%s` (%s, %s) URL: %s",
+                                    attachment.getId(),
+                                    attachment.getFileName(),
+                                    formatFileSize(attachment.getSize()),
+                                    attachment.getContentType() != null ? attachment.getContentType() : "unknown",
+                                    attachment.getUrl()));
+                        }
+                    }
+
+                    return sb.toString();
                 }).toList();
+    }
+
+    private String formatFileSize(int bytes) {
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024 * 1024) return String.format("%.1f KB", bytes / 1024.0);
+        if (bytes < 1024 * 1024 * 1024) return String.format("%.1f MB", bytes / (1024.0 * 1024));
+        return String.format("%.1f GB", bytes / (1024.0 * 1024 * 1024));
     }
 }

--- a/src/main/java/dev/saseq/services/UserService.java
+++ b/src/main/java/dev/saseq/services/UserService.java
@@ -219,17 +219,23 @@ public class UserService {
                     if (!attachments.isEmpty()) {
                         sb.append("\n  Attachments:");
                         for (Message.Attachment attachment : attachments) {
-                            sb.append(String.format("\n    - (Attachment ID: %s) `%s` (%s, %s) URL: %s",
-                                    attachment.getId(),
-                                    attachment.getFileName(),
-                                    formatFileSize(attachment.getSize()),
-                                    attachment.getContentType() != null ? attachment.getContentType() : "unknown",
-                                    attachment.getUrl()));
+                            sb.append("\n    - ").append(formatAttachmentSummary(attachment));
                         }
                     }
 
                     return sb.toString();
                 }).toList();
+    }
+
+    private String formatAttachmentSummary(Message.Attachment attachment) {
+        return String.format(
+                "(Attachment ID: %s) `%s` (%s, %s) URL: %s",
+                attachment.getId(),
+                attachment.getFileName(),
+                formatFileSize(attachment.getSize()),
+                attachment.getContentType() != null ? attachment.getContentType() : "unknown",
+                attachment.getUrl()
+        );
     }
 
     private String formatFileSize(int bytes) {

--- a/src/main/java/dev/saseq/services/UserService.java
+++ b/src/main/java/dev/saseq/services/UserService.java
@@ -210,9 +210,32 @@ public class UserService {
                     String authorName = m.getAuthor().getName();
                     String timestamp = m.getTimeCreated().toString();
                     String content = m.getContentDisplay();
-                    String messageId = m.getId();
+                    String msgId = m.getId();
 
-                    return String.format("- (ID: %s) **[%s]** `%s`: ```%s```", messageId, authorName, timestamp, content);
+                    StringBuilder sb = new StringBuilder();
+                    sb.append(String.format("- (ID: %s) **[%s]** `%s`: ```%s```", msgId, authorName, timestamp, content));
+
+                    List<Message.Attachment> attachments = m.getAttachments();
+                    if (!attachments.isEmpty()) {
+                        sb.append("\n  Attachments:");
+                        for (Message.Attachment attachment : attachments) {
+                            sb.append(String.format("\n    - (Attachment ID: %s) `%s` (%s, %s) URL: %s",
+                                    attachment.getId(),
+                                    attachment.getFileName(),
+                                    formatFileSize(attachment.getSize()),
+                                    attachment.getContentType() != null ? attachment.getContentType() : "unknown",
+                                    attachment.getUrl()));
+                        }
+                    }
+
+                    return sb.toString();
                 }).toList();
+    }
+
+    private String formatFileSize(int bytes) {
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024 * 1024) return String.format("%.1f KB", bytes / 1024.0);
+        if (bytes < 1024 * 1024 * 1024) return String.format("%.1f MB", bytes / (1024.0 * 1024));
+        return String.format("%.1f GB", bytes / (1024.0 * 1024 * 1024));
     }
 }


### PR DESCRIPTION
## Summary
- Add new `get_attachment` tool to retrieve attachment metadata (filename, size, content type, URLs) from a specific message
- Enhance `formatMessages()` in both `MessageService` and `UserService` to include inline attachment info when reading messages
- Add `formatFileSize()` helper to both services for human-readable file sizes

## Test plan
- [ ] `mvn compile` — ensure it builds
- [ ] Call `read_messages` on a channel with attachments — verify attachment metadata appears inline
- [ ] Call `get_attachment` with channel/message that has attachments — verify metadata returned
- [ ] Call `get_attachment` with specific `attachmentId` — verify single attachment returned
- [ ] Call `get_attachment` on message with no attachments — verify "no attachments" message