### PR TITLE
fix: 🔧 support NewsChannel in message and channel tools

### DIFF
--- a/src/main/java/dev/saseq/services/ChannelService.java
+++ b/src/main/java/dev/saseq/services/ChannelService.java
@@ -120,28 +120,47 @@ public class ChannelService {
         Guild guild = getGuild(guildId);
         if (channelId == null || channelId.isEmpty()) throw new IllegalArgumentException("channelId cannot be null");
         GuildChannel guildChannel = guild.getGuildChannelById(channelId);
-        if (!(guildChannel instanceof StandardGuildMessageChannel channel)) {
-            throw new IllegalArgumentException("Channel not found or is not a text/news channel");
-        }
-        var manager = channel.getManager();
-        if (name != null && !name.isEmpty()) manager.setName(name);
-        if (topic != null) manager.setTopic(topic);
-        if (nsfw != null && !nsfw.isEmpty()) manager.setNSFW(Boolean.parseBoolean(nsfw));
-        if (slowmode != null && !slowmode.isEmpty() && guildChannel instanceof TextChannel tc) {
-            tc.getManager().setSlowmode(Integer.parseInt(slowmode));
-        }
-        if (categoryId != null) {
-            if (categoryId.isEmpty()) manager.setParent(null);
-            else {
-                Category category = guild.getCategoryById(categoryId);
-                if (category == null) throw new IllegalArgumentException("Category not found by categoryId");
-                manager.setParent(category);
+        if (guildChannel instanceof TextChannel channel) {
+            var manager = channel.getManager();
+            if (name != null && !name.isEmpty()) manager.setName(name);
+            if (topic != null) manager.setTopic(topic);
+            if (nsfw != null && !nsfw.isEmpty()) manager.setNSFW(Boolean.parseBoolean(nsfw));
+            if (slowmode != null && !slowmode.isEmpty()) manager.setSlowmode(Integer.parseInt(slowmode));
+            if (categoryId != null) {
+                if (categoryId.isEmpty()) manager.setParent(null);
+                else {
+                    Category category = guild.getCategoryById(categoryId);
+                    if (category == null) throw new IllegalArgumentException("Category not found by categoryId");
+                    manager.setParent(category);
+                }
             }
+            if (position != null && !position.isEmpty()) manager.setPosition(Integer.parseInt(position));
+            if (reason != null && !reason.isEmpty()) manager.reason(reason);
+            manager.complete();
+            return "Updated text channel: " + channel.getName() + " (ID: " + channelId + ")";
         }
-        if (position != null && !position.isEmpty()) manager.setPosition(Integer.parseInt(position));
-        if (reason != null && !reason.isEmpty()) manager.reason(reason);
-        manager.complete();
-        return "Updated channel: " + channel.getName() + " (ID: " + channelId + ")";
+        if (guildChannel instanceof StandardGuildMessageChannel channel) {
+            if (slowmode != null && !slowmode.isEmpty()) {
+                throw new IllegalArgumentException("slowmode is supported only for text channels");
+            }
+            var manager = channel.getManager();
+            if (name != null && !name.isEmpty()) manager.setName(name);
+            if (topic != null) manager.setTopic(topic);
+            if (nsfw != null && !nsfw.isEmpty()) manager.setNSFW(Boolean.parseBoolean(nsfw));
+            if (categoryId != null) {
+                if (categoryId.isEmpty()) manager.setParent(null);
+                else {
+                    Category category = guild.getCategoryById(categoryId);
+                    if (category == null) throw new IllegalArgumentException("Category not found by categoryId");
+                    manager.setParent(category);
+                }
+            }
+            if (position != null && !position.isEmpty()) manager.setPosition(Integer.parseInt(position));
+            if (reason != null && !reason.isEmpty()) manager.reason(reason);
+            manager.complete();
+            return "Updated " + channel.getType().name() + " channel: " + channel.getName() + " (ID: " + channelId + ")";
+        }
+        throw new IllegalArgumentException("Channel not found or is not a standard text/news channel");
     }
 
     @Tool(name = "get_channel_info", description = "Get detailed information about a channel")

--- a/src/main/java/dev/saseq/services/ChannelService.java
+++ b/src/main/java/dev/saseq/services/ChannelService.java
@@ -6,6 +6,8 @@ import net.dv8tion.jda.api.entities.channel.concrete.Category;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.StandardGuildChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.StandardGuildMessageChannel;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.beans.factory.annotation.Value;
@@ -118,14 +120,16 @@ public class ChannelService {
         Guild guild = getGuild(guildId);
         if (channelId == null || channelId.isEmpty()) throw new IllegalArgumentException("channelId cannot be null");
         GuildChannel guildChannel = guild.getGuildChannelById(channelId);
-        if (!(guildChannel instanceof TextChannel channel)) {
-            throw new IllegalArgumentException("Channel not found or is not a text channel");
+        if (!(guildChannel instanceof StandardGuildMessageChannel channel)) {
+            throw new IllegalArgumentException("Channel not found or is not a text/news channel");
         }
         var manager = channel.getManager();
         if (name != null && !name.isEmpty()) manager.setName(name);
         if (topic != null) manager.setTopic(topic);
         if (nsfw != null && !nsfw.isEmpty()) manager.setNSFW(Boolean.parseBoolean(nsfw));
-        if (slowmode != null && !slowmode.isEmpty()) manager.setSlowmode(Integer.parseInt(slowmode));
+        if (slowmode != null && !slowmode.isEmpty() && guildChannel instanceof TextChannel tc) {
+            tc.getManager().setSlowmode(Integer.parseInt(slowmode));
+        }
         if (categoryId != null) {
             if (categoryId.isEmpty()) manager.setParent(null);
             else {
@@ -137,7 +141,7 @@ public class ChannelService {
         if (position != null && !position.isEmpty()) manager.setPosition(Integer.parseInt(position));
         if (reason != null && !reason.isEmpty()) manager.reason(reason);
         manager.complete();
-        return "Updated text channel: " + channel.getName() + " (ID: " + channelId + ")";
+        return "Updated channel: " + channel.getName() + " (ID: " + channelId + ")";
     }
 
     @Tool(name = "get_channel_info", description = "Get detailed information about a channel")
@@ -189,8 +193,8 @@ public class ChannelService {
         Guild guild = getGuild(guildId);
         if (channelId == null || channelId.isEmpty()) throw new IllegalArgumentException("channelId cannot be null");
         GuildChannel guildChannel = guild.getGuildChannelById(channelId);
-        if (!(guildChannel instanceof TextChannel channel)) {
-            throw new IllegalArgumentException("Channel not found or is not a text channel");
+        if (!(guildChannel instanceof StandardGuildChannel channel)) {
+            throw new IllegalArgumentException("Channel not found or cannot be moved");
         }
         var manager = channel.getManager();
         if (categoryId != null) {

--- a/src/main/java/dev/saseq/services/MessageService.java
+++ b/src/main/java/dev/saseq/services/MessageService.java
@@ -2,6 +2,7 @@ package dev.saseq.services;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.concrete.NewsChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
@@ -30,6 +31,11 @@ public class MessageService {
         TextChannel textChannel = jda.getTextChannelById(channelId);
         if (textChannel != null) {
             return textChannel;
+        }
+        // Then try news/announcement channel
+        NewsChannel newsChannel = jda.getNewsChannelById(channelId);
+        if (newsChannel != null) {
+            return newsChannel;
         }
         // Then try thread channel
         ThreadChannel threadChannel = jda.getThreadChannelById(channelId);


### PR DESCRIPTION
## Summary
- `send_message` now works on NEWS (announcement) channels
- `move_channel` now works on NEWS, VOICE, FORUM, STAGE channels (not only TEXT)
- `edit_text_channel` now works on both TEXT and NEWS channels
- Slowmode remains TextChannel-only (NewsChannel does not support it)

## Problem
Three tools — `send_message`, `move_channel`, `edit_text_channel` — only accepted `TextChannel`. Any attempt to target a news/announcement channel returned `Channel not found by channelId`, and `move_channel` rejected voice/forum/stage channels with `is not a text channel`. This made it impossible to reorganize servers that mix channel types or post to announcement channels.

## Solution
- `MessageService.getMessageChannelById` now checks `NewsChannel` in addition to `TextChannel` and `ThreadChannel` (all implement `MessageChannel` in JDA 5).
- `ChannelService.editTextChannel` narrows on `StandardGuildMessageChannel`, the common supertype of `TextChannel` and `NewsChannel`. Slowmode stays guarded by a `TextChannel` check because `NewsChannelManager` does not expose `setSlowmode`.
- `ChannelService.moveChannel` narrows on `StandardGuildChannel`, which covers every channel type that can live inside a category (text, news, voice, stage, forum).

## Test plan
- [x] \`mvn clean package -DskipTests\` — builds on JDA 5.6.1
- [x] \`send_message\` to a NEWS channel — verified message posted
- [x] \`edit_text_channel\` rename a TEXT channel — works as before (regression check)
- [ ] \`move_channel\` a NEWS channel between categories
- [ ] \`move_channel\` a VOICE channel between categories
- [ ] \`move_channel\` a FORUM channel between categories
- [ ] \`edit_text_channel\` rename a NEWS channel (topic, nsfw)