### PR TITLE
feat: add forum channel management and edit_category tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Remote MCP Connector:
 
 #### Category Management
 - [`create_category`](): Create a new category for channels
+- [`edit_category`](): Edit a category (rename or move position)
 - [`delete_category`](): Delete a category
 - [`find_category`](): Find a category ID using name and server ID
 - [`list_channels_in_category`](): List of channels in a specific category
@@ -390,6 +391,16 @@ Remote MCP Connector:
 - [`list_invites`](): List all active invites on the server with their statistics
 - [`delete_invite`](): Delete (revoke) an invite so the link stops working
 - [`get_invite_details`](): Get details about a specific invite (works for any public invite)
+
+#### Forum Management
+- [`create_forum_channel`](): Create a new forum channel
+- [`edit_forum_channel`](): Edit settings of a forum channel (name, topic, nsfw, slowmode, category, position, default sort, default layout)
+- [`list_forum_channels`](): List all forum channels in the server
+- [`get_forum_channel_info`](): Get detailed information about a forum channel including tags and settings
+- [`list_forum_tags`](): List all available tags in a forum channel
+- [`create_forum_post`](): Create a new forum post (thread) with an initial message in a forum channel
+- [`list_forum_posts`](): List active posts (threads) in a forum channel
+- [`modify_forum_post`](): Modify a forum post: lock/unlock, archive/unarchive, pin/unpin, or change applied tags
 
 #### Emoji Management
 - [`list_emojis`](): List all custom emojis on the server

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.6.1</version>
+            <version>6.4.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/dev/saseq/configs/DiscordMcpConfig.java
+++ b/src/main/java/dev/saseq/configs/DiscordMcpConfig.java
@@ -14,6 +14,7 @@ import dev.saseq.services.ScheduledEventService;
 import dev.saseq.services.InviteService;
 import dev.saseq.services.ChannelPermissionService;
 import dev.saseq.services.EmojiService;
+import dev.saseq.services.ForumService;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.requests.GatewayIntent;
@@ -39,7 +40,8 @@ public class DiscordMcpConfig {
                                              ScheduledEventService scheduledEventService,
                                              InviteService inviteService,
                                              ChannelPermissionService channelPermissionService,
-                                             EmojiService emojiService) {
+                                             EmojiService emojiService,
+                                             ForumService forumService) {
         return MethodToolCallbackProvider.builder().toolObjects(
                 discordService,
                 messageService,
@@ -54,7 +56,8 @@ public class DiscordMcpConfig {
                 scheduledEventService,
                 inviteService,
                 channelPermissionService,
-                emojiService
+                emojiService,
+                forumService
         ).build();
     }
 

--- a/src/main/java/dev/saseq/services/CategoryService.java
+++ b/src/main/java/dev/saseq/services/CategoryService.java
@@ -94,6 +94,38 @@ public class CategoryService {
      * @param categoryName The name of the category to find.
      * @return A message containing the name and ID of the found category.
      */
+    @Tool(name = "edit_category", description = "Edit a category (rename or move position)")
+    public String editCategory(@ToolParam(description = "Discord server ID", required = false) String guildId,
+                               @ToolParam(description = "Discord category ID") String categoryId,
+                               @ToolParam(description = "New category name", required = false) String name,
+                               @ToolParam(description = "New position in channel list", required = false) String position,
+                               @ToolParam(description = "Reason for audit log", required = false) String reason) {
+        guildId = resolveGuildId(guildId);
+        if (guildId == null || guildId.isEmpty()) {
+            throw new IllegalArgumentException("guildId cannot be null");
+        }
+        if (categoryId == null || categoryId.isEmpty()) {
+            throw new IllegalArgumentException("categoryId cannot be null");
+        }
+        Guild guild = jda.getGuildById(guildId);
+        if (guild == null) {
+            throw new IllegalArgumentException("Discord server not found by guildId");
+        }
+        Category category = guild.getCategoryById(categoryId);
+        if (category == null) {
+            throw new IllegalArgumentException("Category not found by categoryId");
+        }
+        if ((name == null || name.isEmpty()) && (position == null || position.isEmpty())) {
+            throw new IllegalArgumentException("At least one of 'name' or 'position' must be provided");
+        }
+        var manager = category.getManager();
+        if (name != null && !name.isEmpty()) manager.setName(name);
+        if (position != null && !position.isEmpty()) manager.setPosition(Integer.parseInt(position));
+        if (reason != null && !reason.isEmpty()) manager.reason(reason);
+        manager.complete();
+        return "Updated category: " + category.getName() + " (ID: " + category.getId() + ")";
+    }
+
     @Tool(name = "find_category", description = "Find a category ID using name and server ID")
     public String findCategory(@ToolParam(description = "Discord server ID", required = false) String guildId,
                                @ToolParam(description = "Discord category name") String categoryName) {

--- a/src/main/java/dev/saseq/services/ForumService.java
+++ b/src/main/java/dev/saseq/services/ForumService.java
@@ -51,6 +51,14 @@ public class ForumService {
         return forum;
     }
 
+    private ThreadChannel retrieveThreadChannelById(Guild guild, String postId) {
+        ThreadChannel thread = guild.getThreadChannelById(postId);
+        if (thread != null) {
+            return thread;
+        }
+        throw new IllegalArgumentException("Forum post not found by postId");
+    }
+
     @Tool(name = "create_forum_channel", description = "Create a new forum channel")
     public String createForumChannel(@ToolParam(description = "Discord server ID", required = false) String guildId,
                                      @ToolParam(description = "Channel name") String name,
@@ -89,6 +97,17 @@ public class ForumService {
                                    @ToolParam(description = "Reason for audit log", required = false) String reason) {
         Guild guild = getGuild(guildId);
         ForumChannel forum = resolveForumChannel(guild, channelId);
+        boolean hasEditableField = (name != null && !name.isEmpty())
+                || topic != null
+                || (nsfw != null && !nsfw.isEmpty())
+                || (slowmode != null && !slowmode.isEmpty())
+                || categoryId != null
+                || (position != null && !position.isEmpty())
+                || (defaultSort != null && !defaultSort.isEmpty())
+                || (defaultLayout != null && !defaultLayout.isEmpty());
+        if (!hasEditableField) {
+            throw new IllegalArgumentException("At least one forum channel field must be provided");
+        }
         var manager = forum.getManager();
         if (name != null && !name.isEmpty()) manager.setName(name);
         if (topic != null) manager.setTopic(topic);
@@ -238,8 +257,7 @@ public class ForumService {
                                   @ToolParam(description = "Reason for audit log", required = false) String reason) {
         Guild guild = getGuild(guildId);
         if (postId == null || postId.isEmpty()) throw new IllegalArgumentException("postId cannot be null");
-        ThreadChannel thread = guild.getThreadChannelById(postId);
-        if (thread == null) throw new IllegalArgumentException("Forum post not found by postId");
+        ThreadChannel thread = retrieveThreadChannelById(guild, postId);
         if (!(thread.getParentChannel() instanceof ForumChannel)) {
             throw new IllegalArgumentException("Thread is not inside a forum channel");
         }

--- a/src/main/java/dev/saseq/services/ForumService.java
+++ b/src/main/java/dev/saseq/services/ForumService.java
@@ -1,0 +1,270 @@
+package dev.saseq.services;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.channel.attribute.IPostContainer;
+import net.dv8tion.jda.api.entities.channel.concrete.Category;
+import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.dv8tion.jda.api.entities.channel.forums.ForumPost;
+import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
+import net.dv8tion.jda.api.entities.channel.forums.ForumTagSnowflake;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ForumService {
+
+    private final JDA jda;
+
+    @Value("${DISCORD_GUILD_ID:}")
+    private String defaultGuildId;
+
+    public ForumService(JDA jda) {
+        this.jda = jda;
+    }
+
+    private Guild getGuild(String guildId) {
+        if ((guildId == null || guildId.isEmpty()) && defaultGuildId != null && !defaultGuildId.isEmpty()) {
+            guildId = defaultGuildId;
+        }
+        if (guildId == null || guildId.isEmpty()) throw new IllegalArgumentException("guildId cannot be null");
+        Guild guild = jda.getGuildById(guildId);
+        if (guild == null) throw new IllegalArgumentException("Discord server not found by guildId");
+        return guild;
+    }
+
+    private ForumChannel resolveForumChannel(Guild guild, String channelId) {
+        if (channelId == null || channelId.isEmpty()) throw new IllegalArgumentException("channelId cannot be null");
+        GuildChannel channel = guild.getGuildChannelById(channelId);
+        if (!(channel instanceof ForumChannel forum)) {
+            throw new IllegalArgumentException("Channel not found or is not a forum channel");
+        }
+        return forum;
+    }
+
+    @Tool(name = "create_forum_channel", description = "Create a new forum channel")
+    public String createForumChannel(@ToolParam(description = "Discord server ID", required = false) String guildId,
+                                     @ToolParam(description = "Channel name") String name,
+                                     @ToolParam(description = "Category ID", required = false) String categoryId,
+                                     @ToolParam(description = "Default post guidelines / topic", required = false) String topic,
+                                     @ToolParam(description = "Whether channel is NSFW", required = false) String nsfw,
+                                     @ToolParam(description = "Default slowmode for new posts in seconds (0-21600)", required = false) String slowmode,
+                                     @ToolParam(description = "Position in channel list", required = false) String position) {
+        Guild guild = getGuild(guildId);
+        if (name == null || name.isEmpty()) throw new IllegalArgumentException("name cannot be null");
+        var action = guild.createForumChannel(name);
+        if (categoryId != null && !categoryId.isEmpty()) {
+            Category category = guild.getCategoryById(categoryId);
+            if (category == null) throw new IllegalArgumentException("Category not found by categoryId");
+            action.setParent(category);
+        }
+        if (topic != null && !topic.isEmpty()) action.setTopic(topic);
+        if (nsfw != null && !nsfw.isEmpty()) action.setNSFW(Boolean.parseBoolean(nsfw));
+        if (slowmode != null && !slowmode.isEmpty()) action.setSlowmode(Integer.parseInt(slowmode));
+        if (position != null && !position.isEmpty()) action.setPosition(Integer.parseInt(position));
+        ForumChannel forum = action.complete();
+        return "Created forum channel: " + forum.getName() + " (ID: " + forum.getId() + ")";
+    }
+
+    @Tool(name = "edit_forum_channel", description = "Edit settings of a forum channel (name, topic, nsfw, slowmode, category, position, default sort, default layout)")
+    public String editForumChannel(@ToolParam(description = "Discord server ID", required = false) String guildId,
+                                   @ToolParam(description = "Forum channel ID") String channelId,
+                                   @ToolParam(description = "New channel name", required = false) String name,
+                                   @ToolParam(description = "New channel topic / post guidelines", required = false) String topic,
+                                   @ToolParam(description = "Whether channel is NSFW", required = false) String nsfw,
+                                   @ToolParam(description = "Default slowmode for new posts in seconds (0-21600)", required = false) String slowmode,
+                                   @ToolParam(description = "Category ID (empty to remove from category)", required = false) String categoryId,
+                                   @ToolParam(description = "Position in channel list", required = false) String position,
+                                   @ToolParam(description = "Default sort order: RECENT_ACTIVITY or CREATION_TIME", required = false) String defaultSort,
+                                   @ToolParam(description = "Default layout: LIST_VIEW or GALLERY_VIEW", required = false) String defaultLayout,
+                                   @ToolParam(description = "Reason for audit log", required = false) String reason) {
+        Guild guild = getGuild(guildId);
+        ForumChannel forum = resolveForumChannel(guild, channelId);
+        var manager = forum.getManager();
+        if (name != null && !name.isEmpty()) manager.setName(name);
+        if (topic != null) manager.setTopic(topic);
+        if (nsfw != null && !nsfw.isEmpty()) manager.setNSFW(Boolean.parseBoolean(nsfw));
+        if (slowmode != null && !slowmode.isEmpty()) manager.setSlowmode(Integer.parseInt(slowmode));
+        if (categoryId != null) {
+            if (categoryId.isEmpty()) manager.setParent(null);
+            else {
+                Category category = guild.getCategoryById(categoryId);
+                if (category == null) throw new IllegalArgumentException("Category not found by categoryId");
+                manager.setParent(category);
+            }
+        }
+        if (position != null && !position.isEmpty()) manager.setPosition(Integer.parseInt(position));
+        if (defaultSort != null && !defaultSort.isEmpty()) {
+            try {
+                manager.setDefaultSortOrder(IPostContainer.SortOrder.valueOf(defaultSort.toUpperCase()));
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalArgumentException("Invalid defaultSort. Use RECENT_ACTIVITY or CREATION_TIME");
+            }
+        }
+        if (defaultLayout != null && !defaultLayout.isEmpty()) {
+            try {
+                manager.setDefaultLayout(ForumChannel.Layout.valueOf(defaultLayout.toUpperCase()));
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalArgumentException("Invalid defaultLayout. Use LIST_VIEW or GALLERY_VIEW");
+            }
+        }
+        if (reason != null && !reason.isEmpty()) manager.reason(reason);
+        manager.complete();
+        return "Updated forum channel: " + forum.getName() + " (ID: " + forum.getId() + ")";
+    }
+
+    @Tool(name = "list_forum_channels", description = "List all forum channels in the server")
+    public String listForumChannels(@ToolParam(description = "Discord server ID", required = false) String guildId) {
+        Guild guild = getGuild(guildId);
+        List<ForumChannel> forums = guild.getForumChannels();
+        if (forums.isEmpty()) return "No forum channels found in the server.";
+        return "Retrieved " + forums.size() + " forum channels:\n" +
+                forums.stream()
+                        .map(f -> {
+                            String parent = f.getParentCategory() != null ? " [" + f.getParentCategory().getName() + "]" : "";
+                            return "- " + f.getName() + " (ID: " + f.getId() + ")" + parent;
+                        })
+                        .collect(Collectors.joining("\n"));
+    }
+
+    @Tool(name = "get_forum_channel_info", description = "Get detailed information about a forum channel including tags and settings")
+    public String getForumChannelInfo(@ToolParam(description = "Discord server ID", required = false) String guildId,
+                                      @ToolParam(description = "Forum channel ID") String channelId) {
+        Guild guild = getGuild(guildId);
+        ForumChannel forum = resolveForumChannel(guild, channelId);
+        StringBuilder info = new StringBuilder()
+                .append("Name: ").append(forum.getName()).append("\n")
+                .append("ID: ").append(forum.getId()).append("\n")
+                .append("Topic: ").append(forum.getTopic() != null ? forum.getTopic() : "none").append("\n")
+                .append("NSFW: ").append(forum.isNSFW()).append("\n")
+                .append("Slowmode: ").append(forum.getSlowmode()).append("s\n")
+                .append("Position: ").append(forum.getPosition()).append("\n")
+                .append("Default Sort: ").append(forum.getDefaultSortOrder().name()).append("\n")
+                .append("Default Layout: ").append(forum.getDefaultLayout().name()).append("\n");
+        if (forum.getParentCategory() != null) {
+            info.append("Category: ").append(forum.getParentCategory().getName())
+                    .append(" (ID: ").append(forum.getParentCategory().getId()).append(")\n");
+        }
+        List<ForumTag> tags = forum.getAvailableTags();
+        info.append("Tags: ").append(tags.isEmpty() ? "none" : "").append("\n");
+        for (ForumTag tag : tags) {
+            info.append("  - ").append(tag.getName()).append(" (ID: ").append(tag.getId()).append(")")
+                    .append(tag.isModerated() ? " [moderated]" : "").append("\n");
+        }
+        info.append("Active Posts: ").append(forum.getThreadChannels().size()).append("\n");
+        info.append("Created: ").append(forum.getTimeCreated().toLocalDate());
+        return info.toString();
+    }
+
+    @Tool(name = "list_forum_tags", description = "List all available tags in a forum channel")
+    public String listForumTags(@ToolParam(description = "Discord server ID", required = false) String guildId,
+                                @ToolParam(description = "Forum channel ID") String channelId) {
+        Guild guild = getGuild(guildId);
+        ForumChannel forum = resolveForumChannel(guild, channelId);
+        List<ForumTag> tags = forum.getAvailableTags();
+        if (tags.isEmpty()) return "No tags configured on forum: " + forum.getName();
+        return "Retrieved " + tags.size() + " tags on forum " + forum.getName() + ":\n" +
+                tags.stream()
+                        .map(t -> "- " + t.getName() + " (ID: " + t.getId() + ")"
+                                + (t.isModerated() ? " [moderated]" : "")
+                                + (t.getEmoji() != null ? " " + t.getEmoji().getFormatted() : ""))
+                        .collect(Collectors.joining("\n"));
+    }
+
+    @Tool(name = "create_forum_post", description = "Create a new forum post (thread) with an initial message in a forum channel")
+    public String createForumPost(@ToolParam(description = "Discord server ID", required = false) String guildId,
+                                  @ToolParam(description = "Forum channel ID") String channelId,
+                                  @ToolParam(description = "Post title") String title,
+                                  @ToolParam(description = "Content of the initial message") String message,
+                                  @ToolParam(description = "Comma-separated tag IDs to apply", required = false) String tagIds) {
+        Guild guild = getGuild(guildId);
+        ForumChannel forum = resolveForumChannel(guild, channelId);
+        if (title == null || title.isEmpty()) throw new IllegalArgumentException("title cannot be null");
+        if (message == null || message.isEmpty()) throw new IllegalArgumentException("message cannot be null");
+
+        var action = forum.createForumPost(title, MessageCreateData.fromContent(message));
+        if (tagIds != null && !tagIds.isEmpty()) {
+            List<ForumTagSnowflake> tags = new ArrayList<>();
+            for (String raw : tagIds.split(",")) {
+                String id = raw.trim();
+                if (id.isEmpty()) continue;
+                tags.add(ForumTagSnowflake.fromId(id));
+            }
+            if (!tags.isEmpty()) action.setTags(tags);
+        }
+        ForumPost post = action.complete();
+        ThreadChannel thread = post.getThreadChannel();
+        return "Created forum post: " + thread.getName() + " (ID: " + thread.getId()
+                + ") in forum " + forum.getName();
+    }
+
+    @Tool(name = "list_forum_posts", description = "List active posts (threads) in a forum channel")
+    public String listForumPosts(@ToolParam(description = "Discord server ID", required = false) String guildId,
+                                 @ToolParam(description = "Forum channel ID") String channelId) {
+        Guild guild = getGuild(guildId);
+        ForumChannel forum = resolveForumChannel(guild, channelId);
+        List<ThreadChannel> posts = forum.getThreadChannels();
+        if (posts.isEmpty()) return "No active posts found in forum: " + forum.getName();
+        return "Retrieved " + posts.size() + " active posts in forum " + forum.getName() + ":\n" +
+                posts.stream()
+                        .map(p -> {
+                            String tagNames = p.getAppliedTags().stream()
+                                    .map(ForumTag::getName)
+                                    .collect(Collectors.joining(", "));
+                            String tagPart = tagNames.isEmpty() ? "" : " [" + tagNames + "]";
+                            String locked = p.isLocked() ? " (locked)" : "";
+                            String archived = p.isArchived() ? " (archived)" : "";
+                            return "- " + p.getName() + " (ID: " + p.getId() + ")" + tagPart + locked + archived;
+                        })
+                        .collect(Collectors.joining("\n"));
+    }
+
+    @Tool(name = "modify_forum_post", description = "Modify a forum post: lock/unlock, archive/unarchive, pin/unpin, or change applied tags")
+    public String modifyForumPost(@ToolParam(description = "Discord server ID", required = false) String guildId,
+                                  @ToolParam(description = "Forum post (thread) ID") String postId,
+                                  @ToolParam(description = "Lock state (true/false)", required = false) String locked,
+                                  @ToolParam(description = "Archive state (true/false)", required = false) String archived,
+                                  @ToolParam(description = "Pin state (true/false)", required = false) String pinned,
+                                  @ToolParam(description = "Comma-separated tag IDs to set (empty string to clear)", required = false) String tagIds,
+                                  @ToolParam(description = "Reason for audit log", required = false) String reason) {
+        Guild guild = getGuild(guildId);
+        if (postId == null || postId.isEmpty()) throw new IllegalArgumentException("postId cannot be null");
+        ThreadChannel thread = guild.getThreadChannelById(postId);
+        if (thread == null) throw new IllegalArgumentException("Forum post not found by postId");
+        if (!(thread.getParentChannel() instanceof ForumChannel)) {
+            throw new IllegalArgumentException("Thread is not inside a forum channel");
+        }
+
+        if (locked == null && archived == null && pinned == null && tagIds == null) {
+            throw new IllegalArgumentException("At least one of locked, archived, pinned, or tagIds must be provided");
+        }
+
+        var manager = thread.getManager();
+        if (locked != null && !locked.isEmpty()) manager.setLocked(Boolean.parseBoolean(locked));
+        if (archived != null && !archived.isEmpty()) manager.setArchived(Boolean.parseBoolean(archived));
+        if (pinned != null && !pinned.isEmpty()) manager.setPinned(Boolean.parseBoolean(pinned));
+        if (tagIds != null) {
+            List<ForumTagSnowflake> tags = new ArrayList<>();
+            if (!tagIds.isEmpty()) {
+                for (String raw : tagIds.split(",")) {
+                    String id = raw.trim();
+                    if (id.isEmpty()) continue;
+                    tags.add(ForumTagSnowflake.fromId(id));
+                }
+            }
+            manager.setAppliedTags(tags);
+        }
+        if (reason != null && !reason.isEmpty()) manager.reason(reason);
+        manager.complete();
+        return "Updated forum post: " + thread.getName() + " (ID: " + thread.getId() + ")";
+    }
+}


### PR DESCRIPTION
## Summary
- Add new `ForumService` with 8 tools for forum channel management: `create_forum_channel`, `edit_forum_channel`, `list_forum_channels`, `get_forum_channel_info`, `list_forum_tags`, `create_forum_post`, `list_forum_posts`, `modify_forum_post` (lock/archive/pin/tags).
- Add `edit_category` tool to `CategoryService` to rename a category or change its position (previously only create/delete/find/list were available).
- Register `ForumService` in `DiscordMcpConfig` and update README tool list.

## Test plan
- [x] Build passes (`mvn -DskipTests package`)
- [x] Smoke-tested every forum tool against a live Discord server via MCP (list/get/create/edit/modify post on a FORUM channel)
- [x] `edit_category` verified by renaming a category and re-reading with `get_channel_info`