### PR TITLE
✨ Resolve members by display name and expose author IDs in message history

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Remote MCP Connector:
 - [`get_server_info`](): Get detailed discord server information
 
 #### User Management
-- [`get_user_id_by_name`](): Get a Discord user's ID by username in a guild for ping usage `<@id>`
+- [`get_user_id_by_name`](): Get a Discord user's ID by username, global display name, or server nickname in a guild for ping usage `<@id>`
 - [`send_private_message`](): Send a private message to a specific user
 - [`edit_private_message`](): Edit a private message from a specific user
 - [`delete_private_message`](): Delete a private message from a specific user
@@ -326,7 +326,7 @@ Remote MCP Connector:
 - [`send_message`](): Send a message to a specific channel
 - [`edit_message`](): Edit a message from a specific channel
 - [`delete_message`](): Delete a message from a specific channel
-- [`read_messages`](): Read message history from a specific channel (includes attachment metadata, supports `count` 1-100 and optional cursor: `before` or `after` or `around`)
+- [`read_messages`](): Read message history from a specific channel (each message includes the author's display name, username, and user ID, plus attachment metadata; supports `count` 1-100 and optional cursor: `before` or `after` or `around`)
 - [`add_reaction`](): Add a reaction (emoji) to a specific message
 - [`remove_reaction`](): Remove a specified reaction (emoji) from a message
 

--- a/src/main/java/dev/saseq/services/MessageService.java
+++ b/src/main/java/dev/saseq/services/MessageService.java
@@ -2,6 +2,7 @@ package dev.saseq.services;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.NewsChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
@@ -356,13 +357,19 @@ public class MessageService {
     private List<String> formatMessages(List<Message> messages) {
         return messages.stream()
                 .map(m -> {
-                    String authorName = m.getAuthor().getName();
+                    User author = m.getAuthor();
+                    // Prefer the guild nickname/display name when the author is a cached member,
+                    // otherwise fall back to the user's global display name (or username).
+                    String displayName = m.getMember() != null ? m.getMember().getEffectiveName() : author.getEffectiveName();
+                    String username = author.getName();
+                    String authorId = author.getId();
                     String timestamp = m.getTimeCreated().toString();
                     String content = m.getContentDisplay();
                     String msgId = m.getId();
 
                     StringBuilder sb = new StringBuilder();
-                    sb.append(String.format("- (ID: %s) **[%s]** `%s`: ```%s```", msgId, authorName, timestamp, content));
+                    sb.append(String.format("- (ID: %s) **[%s]** (username: %s, userId: %s) `%s`: ```%s```",
+                            msgId, displayName, username, authorId, timestamp, content));
 
                     List<Message.Attachment> attachments = m.getAttachments();
                     if (!attachments.isEmpty()) {

--- a/src/main/java/dev/saseq/services/UserService.java
+++ b/src/main/java/dev/saseq/services/UserService.java
@@ -39,9 +39,9 @@ public class UserService {
      * @param guildId Optional guild/server ID; uses default if not provided
      * @return User ID string if found, or error message
      */
-    @Tool(name = "get_user_id_by_name", description = "Get a Discord user's ID by username in a guild for ping usage <@id>.")
+    @Tool(name = "get_user_id_by_name", description = "Get a Discord user's ID by username, global display name, or server nickname in a guild for ping usage <@id>.")
     public String getUserIdByName(
-            @ToolParam(description = "Discord username (optionally username#discriminator)") String username,
+            @ToolParam(description = "Discord username, display name, or nickname (username may include #discriminator)") String username,
             @ToolParam(description = "Discord server ID", required = false) String guildId) {
         if (username == null || username.isEmpty()) {
             throw new IllegalArgumentException("username cannot be null");
@@ -61,7 +61,12 @@ public class UserService {
             name = username.substring(0, idx);
             discriminatorLocal = username.substring(idx + 1);
         }
-        List<Member> members = guild.getMemberCache().getElementsByUsername(name, true);
+        // Query the gateway (requires the GUILD_MEMBERS intent) instead of the cold member cache,
+        // and match against username, global display name, and server nickname — not just username.
+        final String finalName = name;
+        List<Member> members = retrieveMembersByPrefix(guild, name).stream()
+                .filter(m -> nameMatches(m, finalName))
+                .toList();
         if (discriminatorLocal != null) {
             final String finalDiscriminator = discriminatorLocal;
             members = members.stream()
@@ -69,15 +74,30 @@ public class UserService {
                     .toList();
         }
         if (members.isEmpty()) {
-            throw new IllegalArgumentException("No user found with username " + username);
+            throw new IllegalArgumentException("No user found with name " + username);
         }
         if (members.size() > 1) {
             String userList = members.stream()
                     .map(m -> m.getUser().getName() + "#" + m.getUser().getDiscriminator() + " (ID: " + m.getUser().getId() + ")")
                     .collect(Collectors.joining(", "));
-            throw new IllegalArgumentException("Multiple users found with username '" + username + "'. List: " + userList + ". Please specify the full username#discriminator.");
+            throw new IllegalArgumentException("Multiple users found with name '" + username + "'. List: " + userList + ". Please specify the full username#discriminator.");
         }
         return members.get(0).getUser().getId();
+    }
+
+    private List<Member> retrieveMembersByPrefix(Guild guild, String prefix) {
+        // retrieveMembersByPrefix caps the limit at 100; request the maximum so exact-match
+        // filtering downstream has the widest set of candidates to choose from.
+        List<Member> members = guild.retrieveMembersByPrefix(prefix, 100).get();
+        return members != null ? members : List.of();
+    }
+
+    private boolean nameMatches(Member member, String name) {
+        User user = member.getUser();
+        return name.equalsIgnoreCase(user.getName())
+                || name.equalsIgnoreCase(user.getGlobalName())
+                || name.equalsIgnoreCase(member.getNickname())
+                || name.equalsIgnoreCase(member.getEffectiveName());
     }
 
     /**
@@ -262,13 +282,17 @@ public class UserService {
     private List<String> formatMessages(List<Message> messages) {
         return messages.stream()
                 .map(m -> {
-                    String authorName = m.getAuthor().getName();
+                    User author = m.getAuthor();
+                    String displayName = author.getEffectiveName();
+                    String username = author.getName();
+                    String authorId = author.getId();
                     String timestamp = m.getTimeCreated().toString();
                     String content = m.getContentDisplay();
                     String msgId = m.getId();
 
                     StringBuilder sb = new StringBuilder();
-                    sb.append(String.format("- (ID: %s) **[%s]** `%s`: ```%s```", msgId, authorName, timestamp, content));
+                    sb.append(String.format("- (ID: %s) **[%s]** (username: %s, userId: %s) `%s`: ```%s```",
+                            msgId, displayName, username, authorId, timestamp, content));
 
                     List<Message.Attachment> attachments = m.getAttachments();
                     if (!attachments.isEmpty()) {


### PR DESCRIPTION
## Problem

Messages surface a member's **display name / server nickname** (e.g. `tnadz`), but there's no reliable path from that to a user ID:

- `get_user_id_by_name` matches only the account **username**, off the cold member cache — so it silently misses whenever the caller only knows the display name or nickname shown in chat.
- `read_messages` / `read_private_messages` show an author name but no **user ID**, so you can't ping or reconcile the author without a separate (often failing) name lookup.

## Changes (additive; no existing tool signatures change)

- **`get_user_id_by_name`** now matches **username, global display name, and server nickname**, and queries the gateway (via `Guild#retrieveMembersByPrefix`, which needs the `GUILD_MEMBERS` privileged intent) instead of the cold cache — so it resolves the common "I only know the name shown in the channel" case.
- **`read_messages` / `read_private_messages`** now include each author's raw **username** and **user ID** alongside the display name, e.g.:
  `- (ID: …) **[Ross Smith]** (username: tnadz, userId: 87043132637614080) …`

## Relationship to #33

#33 adds `get_member_by_id` and a `search_members` tool. This PR is complementary and intentionally does **not** add a `search_members` tool to avoid duplicating it. It covers two gaps #33 leaves open:
1. #33 does not change `get_user_id_by_name`, which remains username-only — this PR fixes that.
2. #33's `read_messages` change surfaces the author ID but drops the display name; this PR keeps the display name **and** adds username + ID.

The two PRs can land in either order; if they overlap on `formatMessages`, the conflict is trivial.

## Notes

Member resolution requires the **GUILD_MEMBERS** privileged intent enabled both in the Discord Developer Portal and in the gateway intents. The code already enables it in `JDABuilder`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)